### PR TITLE
Make baseurl root

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Site settings
 title: Community Health Explorer
-baseurl: "/community-health-explorer" # the subpath of your site, e.g. /blog
+baseurl: "/" # the subpath of your site, e.g. /blog
 
 year: "2016"
 


### PR DESCRIPTION
Allows for correct relative paths for use in new subdomain, healthexplorer.phila.gov.